### PR TITLE
fix: documentation capitlization typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Example:
 - name: Type Check Code Base
   uses: mrcjkb/lua-typecheck-action@v0.1.2
   with:
-    checkLevel: Error
+    checklevel: Error
 ```
 
 ### `directories`


### PR DESCRIPTION
The docs have it once (in the copy-pastable) as `checkLevel`, but should be `checklevel` I believe